### PR TITLE
Support for explicitly named step functions

### DIFF
--- a/src/cucumberl.erl
+++ b/src/cucumberl.erl
@@ -150,8 +150,14 @@ process_line({LineNum, Line},
                     end,
                 R = lists:foldl(
                       fun (StepModule, undefined) ->
-                              StepModule:step([G | TokensTail],
-                                              {Line, LineNum});
+                              case erlang:function_exported(StepModule, G, 2) of
+                                  true ->
+                                      apply(StepModule, G, [TokensTail,
+                                                            {Line, LineNum}]);
+                                  false ->
+                                      StepModule:step([G | TokensTail],
+                                                        {Line, LineNum})
+                              end;
                           (_, Acc) -> Acc
                       end,
                       undefined, StepModules),

--- a/src/sample.erl
+++ b/src/sample.erl
@@ -4,14 +4,13 @@
 
 % Step definitions for the sample calculator Addition feature.
 
-step([given, i, have, entered, N, into, the, calculator], _) ->
-    enter(list_to_integer(atom_to_list(N)));
+given([i, have, entered, N, into, the, calculator], _) ->
+    enter(list_to_integer(atom_to_list(N))).
 
-step(['when', i, press, Op], _) ->
-    press(Op);
+'when'([i, press, Op], _) -> press(Op).
 
-step(['then', the, result, should, be, Result, on, the, screen], _) ->
-    [list_to_integer(atom_to_list(Result))] =:= get(calculator);
+then([the, result, should, be, Result, on, the, screen], _) ->
+    [list_to_integer(atom_to_list(Result))] =:= get(calculator).
 
 step(_, _) -> undefined.
 


### PR DESCRIPTION
This patch provides step module authors with the
ability to export functions for given, when, then
and so on. The change does not break existing code
and modules may continue to export step/2 instead.
